### PR TITLE
do not rely on inheritance hierarchy in scipy sparse matrix

### DIFF
--- a/src/diversity/abundance.py
+++ b/src/diversity/abundance.py
@@ -18,7 +18,7 @@ from typing import Iterable, Union
 
 from numpy import arange, ndarray
 from pandas import DataFrame, RangeIndex
-from scipy.sparse import spmatrix, diags
+from scipy.sparse import spmatrix, diags, issparse
 
 
 class Abundance:
@@ -156,10 +156,11 @@ def make_abundance(counts: Union[DataFrame, spmatrix, ndarray]) -> Abundance:
     """
     if isinstance(counts, DataFrame):
         return AbundanceFromDataFrame(counts=counts)
-    elif isinstance(counts, spmatrix):
-        return AbundanceFromSparseArray(counts=counts)
-    elif isinstance(counts, ndarray):
-        return Abundance(counts=counts)
+    elif hasattr(counts, 'shape'):
+        if issparse(counts):
+            return AbundanceFromSparseArray(counts=counts)
+        else:
+            return Abundance(counts=counts)
     else:
         raise NotImplementedError(
             f"Type {type(counts)} is not supported for argument "

--- a/tests/abundance_test.py
+++ b/tests/abundance_test.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from numpy import allclose, array, ndarray
 from pandas import DataFrame
 from pytest import fixture, mark, raises
-from scipy.sparse import csr_array, spmatrix
+from scipy.sparse import csr_array, spmatrix, issparse
 
 from diversity.abundance import (
     Abundance,
@@ -267,7 +267,7 @@ class TestSparseAbundance:
 
     def test_subcommunity_abundance(self, test_case):
         abundance = make_abundance(counts=test_case.counts)
-        assert isinstance(abundance.subcommunity_abundance, spmatrix)
+        assert issparse(abundance.subcommunity_abundance)
         assert allclose(
             abundance.subcommunity_abundance.data,
             test_case.subcommunity_abundance.data,
@@ -289,7 +289,7 @@ class TestSparseAbundance:
 
     def test_normalized_subcommunity_abundance(self, test_case):
         abundance = make_abundance(counts=test_case.counts)
-        assert isinstance(abundance.normalized_subcommunity_abundance, spmatrix)
+        assert issparse(abundance.normalized_subcommunity_abundance)
         assert allclose(
             abundance.normalized_subcommunity_abundance.data,
             test_case.normalized_subcommunity_abundance.data,


### PR DESCRIPTION
Implementation of scipy's sparse matrices is in flux as they transition to an array-compatible API: see comments here:
https://docs.scipy.org/doc/scipy/reference/sparse.html
Tests were failing because csr_array no longer inherits from spmatrix (in version 3.11 of scipy). Type testing now less dependent on the inheritance hierarchy (which is merely an implementation detail in a duck-typing language such as Python) and now relies on functionality (does the abundance matrix have a "shape"?) and scipy's opinion of whether it's a sparse matrix (which should be internally consistent within a given version of scipy).